### PR TITLE
Version bump — client/package.json updated from 0.5.3 → 0.5.4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Browser (React) ←→ WebSocket ←→ Node.js bridge server ←→ TCP port 22
 
 - Real-time channel control: fader gain, mute, Always On
 - Per-channel input source (Analog / Network), mic sensitivity, and 48V phantom power
-- Per-channel EQ: lo-cut filter (25–320 Hz) and hi-shelf gain (±12 dB) with collapsible panel in each channel strip
+- Per-channel EQ: lo-cut filter (25–320 Hz) and hi-shelf gain (±12 dB) with collapsible panel in each channel strip; values are click-to-edit
 - VU meter display driven by SCM820 SAMPLE frames
 - Output A/B controls with mute and gain
 - Direct output source assignment (channels 10–17)
@@ -22,6 +22,9 @@ Browser (React) ←→ WebSocket ←→ Node.js bridge server ←→ TCP port 22
 - Live device info: Device ID, serial number, firmware version, network configuration
 - Fader resolution toggle (Coarse / Fine) per channel strip
 - In-browser debug console with live audio command traffic and a **Hide Peaks** filter (on by default)
+- Tab bar with reorderable tabs (session-based); IntelliMix and DFR tabs show "Coming Soon!"
+- Automatic update check — checks GitHub releases every 24 hours; amber **ⓘ** icon in the header when a new release is available
+- **Automatically Check For Updates** preference in the status popover (enabled by default, persisted in `localStorage`)
 - PWA — installable from the browser on desktop and mobile
 - Docker support for network-accessible deployment
 - Mock SCM820 server for local development without hardware

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scm820-client",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,9 +1,22 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useSCM820 } from './hooks/useSCM820.js';
 import { useMixerStore } from './state/mixerStore.js';
 import { MixerLayout } from './components/MixerLayout.jsx';
 import { ConnectionModal } from './components/ConnectionModal.jsx';
 import { DebugDrawer } from './components/DebugDrawer.jsx';
+
+const GITHUB_RELEASES_API = 'https://api.github.com/repos/L252-Media-Production/shure-scm820-webapp/releases/latest';
+const UPDATE_CHECK_MS = 24 * 60 * 60 * 1000;
+
+function semverGt(a, b) {
+  const parse = (v) => v.replace(/^v/, '').split('.').map(Number);
+  const pa = parse(a), pb = parse(b);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return true;
+    if ((pa[i] || 0) < (pb[i] || 0)) return false;
+  }
+  return false;
+}
 
 function InfoRow({ label, value }) {
   return (
@@ -33,7 +46,7 @@ function SegBtn({ active, onClick, children }) {
   );
 }
 
-function StatusPopover({ deviceInfo, connected, sendSet, onHostChange, xtouchInfo, xtouchConnected }) {
+function StatusPopover({ deviceInfo, connected, sendSet, onHostChange, xtouchInfo, xtouchConnected, autoCheckUpdates, onAutoCheckChange }) {
   const [host, setHost] = useState(deviceInfo.host || '');
   const [expanded, setExpanded] = useState(false);
   const [lastActiveRate, setLastActiveRate] = useState(1000);
@@ -243,6 +256,20 @@ function StatusPopover({ deviceInfo, connected, sendSet, onHostChange, xtouchInf
           </div>
         )}
       </div>
+
+      {/* Preferences */}
+      <div className="border-t border-zinc-700 pt-3 mt-1">
+        <div className="text-[10px] text-zinc-500 uppercase tracking-wider mb-2">Preferences</div>
+        <label className="flex items-center gap-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={autoCheckUpdates}
+            onChange={(e) => onAutoCheckChange(e.target.checked)}
+            className="w-3.5 h-3.5 accent-blue-500"
+          />
+          <span className="text-xs text-zinc-400">Automatically Check For Updates?</span>
+        </label>
+      </div>
     </div>
   );
 }
@@ -258,6 +285,55 @@ export default function App() {
   const [showPopover, setShowPopover] = useState(false);
   const [zoom, setZoom] = useState(100);
   const hasConnectedRef = useRef(false);
+
+  const [autoCheckUpdates, setAutoCheckUpdates] = useState(
+    () => localStorage.getItem('autoCheckUpdates') !== 'false'
+  );
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  const [latestReleaseUrl, setLatestReleaseUrl] = useState(null);
+
+  const runUpdateCheck = useCallback(() => {
+    fetch(GITHUB_RELEASES_API)
+      .then((r) => r.json())
+      .then((data) => {
+        const tag = data.tag_name;
+        const url = data.html_url;
+        localStorage.setItem('updateLastCheck', String(Date.now()));
+        localStorage.setItem('updateLatestTag', tag || '');
+        localStorage.setItem('updateLatestUrl', url || '');
+        if (tag && semverGt(tag, __APP_VERSION__)) {
+          setUpdateAvailable(true);
+          setLatestReleaseUrl(url);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!autoCheckUpdates) return;
+    const lastCheck = parseInt(localStorage.getItem('updateLastCheck') || '0', 10);
+    const cachedTag = localStorage.getItem('updateLatestTag') || '';
+    const cachedUrl = localStorage.getItem('updateLatestUrl') || '';
+    if (cachedTag && cachedUrl && Date.now() - lastCheck < UPDATE_CHECK_MS) {
+      if (semverGt(cachedTag, __APP_VERSION__)) {
+        setUpdateAvailable(true);
+        setLatestReleaseUrl(cachedUrl);
+      }
+      return;
+    }
+    runUpdateCheck();
+  }, [autoCheckUpdates, runUpdateCheck]);
+
+  function handleAutoCheckChange(checked) {
+    setAutoCheckUpdates(checked);
+    localStorage.setItem('autoCheckUpdates', String(checked));
+    if (!checked) {
+      setUpdateAvailable(false);
+      setLatestReleaseUrl(null);
+    } else {
+      runUpdateCheck();
+    }
+  }
 
   useEffect(() => {
     if (connected) {
@@ -288,6 +364,17 @@ export default function App() {
           <span className="text-zinc-500 text-xs font-mono uppercase tracking-widest">Shure</span>
           <span className="text-zinc-200 font-bold tracking-wide">SCM820 Virtual Mixer</span>
           <span className="text-zinc-600 text-xs font-mono">v{__APP_VERSION__}</span>
+          <button
+            onClick={() => updateAvailable && window.open(latestReleaseUrl, '_blank')}
+            title={updateAvailable ? 'Update available — click to view release' : 'Up to date'}
+            className={`w-4 h-4 rounded-full border flex items-center justify-center text-[10px] font-bold transition-colors ${
+              updateAvailable
+                ? 'border-amber-400 text-amber-400 hover:bg-amber-400/10 cursor-pointer'
+                : 'border-zinc-600 text-zinc-600 cursor-default'
+            }`}
+          >
+            i
+          </button>
         </div>
 
         {/* Zoom control */}
@@ -331,6 +418,8 @@ export default function App() {
                 onHostChange={handleHostChange}
                 xtouchInfo={xtouchInfo}
                 xtouchConnected={xtouchConnected}
+                autoCheckUpdates={autoCheckUpdates}
+                onAutoCheckChange={handleAutoCheckChange}
               />
             </>
           )}

--- a/client/src/components/MixerLayout.jsx
+++ b/client/src/components/MixerLayout.jsx
@@ -7,36 +7,106 @@ import { useMixerStore } from '../state/mixerStore.js';
 const INPUT_CHANNELS = [1, 2, 3, 4, 5, 6, 7, 8];
 const AUX_CHANNEL = 9;
 
-const TABS = [
-  { id: 'inputs', label: 'Inputs' },
-  { id: 'outputs', label: 'Outputs' },
+const DEFAULT_TABS = [
+  { id: 'inputs',     label: 'Inputs'    },
+  { id: 'outputs',    label: 'Outputs'   },
+  { id: 'intellimix', label: 'IntelliMix'},
+  { id: 'dfr',        label: 'DFR'       },
 ];
+
+function loadTabOrder() {
+  try {
+    const stored = sessionStorage.getItem('tabOrder');
+    if (stored) {
+      const ids = JSON.parse(stored);
+      const byId = Object.fromEntries(DEFAULT_TABS.map((t) => [t.id, t]));
+      const ordered = ids.filter((id) => byId[id]).map((id) => byId[id]);
+      const missing = DEFAULT_TABS.filter((t) => !ids.includes(t.id));
+      return [...ordered, ...missing];
+    }
+  } catch {}
+  return DEFAULT_TABS;
+}
+
+function saveTabOrder(tabs) {
+  try {
+    sessionStorage.setItem('tabOrder', JSON.stringify(tabs.map((t) => t.id)));
+  } catch {}
+}
+
+function ComingSoon({ label }) {
+  return (
+    <div className="flex flex-col items-center justify-center flex-1 gap-3 py-20 text-zinc-600">
+      <div className="text-4xl">🚧</div>
+      <div className="text-lg font-bold text-zinc-500">{label}</div>
+      <div className="text-sm font-mono">Coming Soon!</div>
+    </div>
+  );
+}
 
 export function MixerLayout({ sendSet, meterLevelsRef }) {
   const channels = useMixerStore((s) => s.channels);
-  const [activeTab, setActiveTab] = useState('inputs');
+  const [tabs, setTabs] = useState(loadTabOrder);
+  const [activeTab, setActiveTab] = useState(() => loadTabOrder()[0].id);
+  const [editing, setEditing] = useState(false);
+
+  function move(index, dir) {
+    const next = [...tabs];
+    const to = index + dir;
+    if (to < 0 || to >= next.length) return;
+    [next[index], next[to]] = [next[to], next[index]];
+    setTabs(next);
+    saveTabOrder(next);
+  }
 
   return (
     <div className="flex flex-col flex-1">
       {/* Tab bar */}
       <div className="flex items-center gap-1 px-4 pt-3 border-b border-zinc-700">
-        {TABS.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={`px-4 py-1.5 text-xs font-bold rounded-t-lg transition-colors border-b-2 -mb-px ${
-              activeTab === tab.id
-                ? 'text-zinc-100 border-blue-500 bg-zinc-800'
-                : 'text-zinc-500 border-transparent hover:text-zinc-300'
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
+        {tabs.map((tab, i) =>
+          editing ? (
+            <div key={tab.id} className="flex items-center gap-0.5 px-2 py-1 bg-zinc-700 rounded-t text-xs text-zinc-300 font-bold">
+              <button
+                onClick={() => move(i, -1)}
+                disabled={i === 0}
+                className="text-zinc-500 hover:text-zinc-200 disabled:opacity-20 text-[10px] px-0.5"
+              >‹</button>
+              <span className="px-1">{tab.label}</span>
+              <button
+                onClick={() => move(i, 1)}
+                disabled={i === tabs.length - 1}
+                className="text-zinc-500 hover:text-zinc-200 disabled:opacity-20 text-[10px] px-0.5"
+              >›</button>
+            </div>
+          ) : (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`px-4 py-1.5 text-xs font-bold rounded-t-lg transition-colors border-b-2 -mb-px ${
+                activeTab === tab.id
+                  ? 'text-zinc-100 border-blue-500 bg-zinc-800'
+                  : 'text-zinc-500 border-transparent hover:text-zinc-300'
+              }`}
+            >
+              {tab.label}
+            </button>
+          )
+        )}
+
+        <button
+          onClick={() => setEditing((v) => !v)}
+          className={`ml-auto px-2 py-0.5 text-[9px] font-bold rounded transition-colors ${
+            editing
+              ? 'bg-blue-600 text-white'
+              : 'text-zinc-600 hover:text-zinc-300'
+          }`}
+        >
+          {editing ? 'Done' : 'Edit'}
+        </button>
       </div>
 
       {/* Tab content */}
-      {activeTab === 'inputs' && (
+      {!editing && activeTab === 'inputs' && (
         <div className="flex items-start gap-3 p-4 overflow-x-auto">
           {INPUT_CHANNELS.map((ch) => (
             <ChannelStrip
@@ -60,8 +130,22 @@ export function MixerLayout({ sendSet, meterLevelsRef }) {
         </div>
       )}
 
-      {activeTab === 'outputs' && (
+      {!editing && activeTab === 'outputs' && (
         <OutputTab sendSet={sendSet} meterLevelsRef={meterLevelsRef} />
+      )}
+
+      {!editing && activeTab === 'intellimix' && (
+        <ComingSoon label="IntelliMix" />
+      )}
+
+      {!editing && activeTab === 'dfr' && (
+        <ComingSoon label="DFR" />
+      )}
+
+      {editing && (
+        <div className="flex items-center justify-center flex-1 text-zinc-600 text-sm font-mono py-16">
+          Use ‹ › to reorder tabs. Order resets when you close the browser.
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
feat: Info icon — a small i button appears in the header next to the version number; zinc/grey when up to date, amber with a hover effect when an update is available; clicking it opens the latest release URL in a new tab.

StatusPopover props — autoCheckUpdates and onAutoCheckChange are now passed to <StatusPopover>, wiring the Preferences checkbox correctly.